### PR TITLE
Add option to change the python interpreter

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,15 @@ Create a `.cookie-cutter.yaml` file in your `$HOME/.config/` directory _or_ a be
             split_direction: "horizontal"
             command: ./manage runserver
 ```
+
+Optionally, you can set the python interpreter to use, it defaults to python3:
+
+```shell
+set-option -g @cookie_cutter_python "python3"
+```
+
+Be sure it has PyYAML available, you can use `uv` to run it with the `pyyaml` package:
+
+```shell
+set-option -g @cookie_cutter_python "uv run --with pyyaml"
+```

--- a/cookie-cutter.tmux
+++ b/cookie-cutter.tmux
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+set-option -go @cookie_cutter_python "python3"
 
-tmux set-hook -g session-created 'run-shell "python3 $TMUX_PLUGIN_MANAGER_PATH/tmux-cookie-cutter/scripts/cookie_cutter.py'
+tmux set-hook -g session-created 'run-shell "$(tmux show-options -g -v @cookie_cutter_python) $TMUX_PLUGIN_MANAGER_PATH/tmux-cookie-cutter/scripts/cookie_cutter.py'


### PR DESCRIPTION
If the default python interpreter doesn't have PyYAML installed it will not work. This adds the option to use a different interpreter that could be inside a virtualenv or created with uv