### PR TITLE
Enable re-running cookie cutter config

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,15 @@ Be sure it has PyYAML available, you can use `uv` to run it with the `pyyaml` pa
 set-option -g @cookie_cutter_python "uv run --with pyyaml"
 ```
 
+### Reloading window configuration
+
+You can reload the configuration for an individual tmux window without restarting the session.
+
+1. Focus the window you want to reload.
+2. Press `<prefix> + Ctrl-c`.
+   
+Only the active window is affected; other windows remain unchanged.
+
 ## Support
 
 If you find Tmux Cookie Cutter useful and would like to support its development, you can buy me a coffee ☕ — it’s very much appreciated!

--- a/cookie-cutter.tmux
+++ b/cookie-cutter.tmux
@@ -3,7 +3,9 @@
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 SCRIPT_PATH="$CURRENT_DIR/scripts/cookie_cutter.py"
+REFRESH_WINDOW_SCRIPT_PATH="$CURRENT_DIR/scripts/re_run_cookie_cutter.py"
 
 tmux set-option -go @cookie_cutter_python "python3"
+tmux bind C-c run-shell "$(tmux show-options -g -v @cookie_cutter_python) $REFRESH_WINDOW_SCRIPT_PATH"
 
 tmux set-hook -g session-created "run-shell \"\$(tmux show-options -g -v @cookie_cutter_python) \\\"$SCRIPT_PATH\\\"\""

--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -4,3 +4,8 @@ import enum
 class SplitDirection(enum.StrEnum):
     horizontal = "horizontal"
     vertical = "vertical"
+
+
+class WindowNamingOption(enum.StrEnum):
+    create = "create"
+    rename = "rename"

--- a/scripts/cookie_cutter.py
+++ b/scripts/cookie_cutter.py
@@ -1,147 +1,12 @@
 import importlib
-import typing
-from pathlib import Path
 
 constants = importlib.import_module("constants")
 data_objects = importlib.import_module("data_objects")
 tmux_commands = importlib.import_module("tmux_commands")
+utils = importlib.import_module("utils")
 
 
-FILE_NAME = ".tmux-cookie-cutter.yaml"
-CONFIG_PATH = Path.joinpath(Path.home(), ".config")
-
-
-def get_config_file_path() -> Path | None:
-    file_path = Path(FILE_NAME)
-    if file_path.is_file():
-        return file_path
-    else:
-        default_path = Path.joinpath(CONFIG_PATH, FILE_NAME)
-        if Path(default_path).is_file():
-            return default_path
-    return None
-
-
-def parse_config_file(config_file_path: Path) -> dict[str, typing.Any] | None:
-    try:
-        import yaml
-
-        return yaml.safe_load(open(config_file_path))
-    except ModuleNotFoundError:
-        tmux_commands.show_warning_message()
-        return None
-
-
-def generate_pane_configurations(
-    configuration: dict[str, typing.Any],
-) -> list[data_objects.PaneConfig]:
-    pane_configs = configuration.get("panes")
-
-    if pane_configs is None:
-        return []
-
-    return [
-        data_objects.PaneConfig(
-            command=pane_config.get("command"),
-            split_direction=constants.SplitDirection(pane_config["split_direction"]),
-            envvars=configuration.get("envvars"),
-            setup_command=configuration.get("setup_command"),
-            size=pane_config.get("size"),
-        )
-        for pane_config in pane_configs
-    ]
-
-
-def generate_configurations(
-    parsed_configuration: dict[str, typing.Any],
-) -> list[data_objects.Config]:
-    return [
-        data_objects.Config(
-            name=configuration["name"],
-            command=configuration.get("command"),
-            envvars=configuration.get("envvars"),
-            setup_command=configuration.get("setup_command"),
-            panes=generate_pane_configurations(
-                configuration=configuration,
-            ),
-        )
-        for configuration in parsed_configuration["default_windows"]
-    ]
-
-
-def parse_shared_values(
-    parsed_configuration: dict[str, typing.Any],
-) -> data_objects.SharedValues:
-    configuration = parsed_configuration.get("shared")
-    if not configuration:
-        return data_objects.SharedValues(
-            envvars=None,
-            setup_command=None,
-        )
-    return data_objects.SharedValues(
-        envvars=configuration.get("envvars"),
-        setup_command=configuration.get("setup_command"),
-    )
-
-
-def run_pane_configuration(
-    pane_configuration: data_objects.PaneConfig,
-    shared_configuration: data_objects.SharedValues,
-    window_index: int,
-    pane_index: int,
-    session: str,
-) -> None:
-    tmux_commands.split_window(
-        index=window_index,
-        session=session,
-        direction=pane_configuration.split_direction,
-    )
-    tmux_commands.set_environment_variables(
-        envvars=shared_configuration.envvars,
-        index=window_index,
-        session=session,
-    )
-    tmux_commands.run_setup_command(
-        command=shared_configuration.setup_command,
-        index=window_index,
-        session=session,
-    )
-    tmux_commands.set_environment_variables(
-        envvars=pane_configuration.envvars,
-        index=window_index,
-        session=session,
-    )
-    tmux_commands.run_setup_command(
-        command=pane_configuration.setup_command,
-        index=window_index,
-        session=session,
-    )
-    tmux_commands.run_command(
-        command=pane_configuration.command,
-        index=window_index,
-        session=session,
-    )
-    if not pane_configuration.size:
-        return
-
-    match pane_configuration.split_direction:
-        case constants.SplitDirection.vertical:
-            tmux_commands.resize_pane_horizontally(
-                window_index=window_index,
-                pane_index=pane_index,
-                session=session,
-                size=pane_configuration.size,
-            )
-        case constants.SplitDirection.horizontal:
-            tmux_commands.resize_pane_vertically(
-                window_index=window_index,
-                pane_index=pane_index,
-                session=session,
-                size=pane_configuration.size,
-            )
-
-
-def run_configurations(
+def run_cookie_cutter(
     configurations: list[data_objects.Config],
     shared_configuration: data_objects.SharedValues,
     session_name: str,
@@ -149,51 +14,20 @@ def run_configurations(
     pane_base_index: int,
 ) -> None:
     for index, configuration in enumerate(configurations):
-        if index == 0:
-            tmux_commands.rename_tmux_window(
-                name=configuration.name,
-                session=session_name,
-                index=index + window_base_index,
-            )
-        else:
-            tmux_commands.create_tmux_window(
-                name=configuration.name, session=session_name
-            )
-
-        tmux_commands.set_environment_variables(
-            envvars=shared_configuration.envvars,
-            index=index + window_base_index,
-            session=session_name,
+        create_or_rename = (
+            constants.WindowNamingOption.rename
+            if index == 0
+            else constants.WindowNamingOption.create
         )
-        tmux_commands.run_setup_command(
-            command=shared_configuration.setup_command,
-            index=index + window_base_index,
-            session=session_name,
+        utils.run_configuration(
+            configuration=configuration,
+            shared_configuration=shared_configuration,
+            session_name=session_name,
+            window_base_index=window_base_index,
+            pane_base_index=pane_base_index,
+            index=index,
+            create_or_rename=create_or_rename,
         )
-        tmux_commands.set_environment_variables(
-            envvars=configuration.envvars,
-            index=index + window_base_index,
-            session=session_name,
-        )
-        tmux_commands.run_setup_command(
-            command=configuration.setup_command,
-            index=index + window_base_index,
-            session=session_name,
-        )
-        tmux_commands.run_command(
-            command=configuration.command,
-            index=index + window_base_index,
-            session=session_name,
-        )
-
-        for pane_index, pane in enumerate(configuration.panes):
-            run_pane_configuration(
-                pane_configuration=pane,
-                shared_configuration=shared_configuration,
-                window_index=index + window_base_index,
-                pane_index=pane_index + pane_base_index + 1,
-                session=session_name,
-            )
 
     tmux_commands.select_window(
         window_index=window_base_index + 1,
@@ -206,7 +40,7 @@ def run_configurations(
 
 
 def main() -> None:
-    config_file_path = get_config_file_path()
+    config_file_path = utils.get_config_file_path()
     window_base_index = tmux_commands.get_window_base_index()
     pane_base_index = tmux_commands.get_pane_base_index()
     session_name = tmux_commands.get_tmux_session_name()
@@ -214,14 +48,16 @@ def main() -> None:
     if not config_file_path:
         return
 
-    parsed_configuration = parse_config_file(config_file_path=config_file_path)
+    parsed_configuration = utils.parse_config_file(config_file_path=config_file_path)
 
     if parsed_configuration is None:
         return
 
-    configurations = generate_configurations(parsed_configuration=parsed_configuration)
-    shared = parse_shared_values(parsed_configuration=parsed_configuration)
-    run_configurations(
+    configurations = utils.generate_configurations(
+        parsed_configuration=parsed_configuration
+    )
+    shared = utils.parse_shared_values(parsed_configuration=parsed_configuration)
+    run_cookie_cutter(
         configurations=configurations,
         shared_configuration=shared,
         session_name=session_name,

--- a/scripts/re_run_cookie_cutter.py
+++ b/scripts/re_run_cookie_cutter.py
@@ -1,0 +1,42 @@
+import importlib
+
+constants = importlib.import_module("constants")
+data_objects = importlib.import_module("data_objects")
+tmux_commands = importlib.import_module("tmux_commands")
+utils = importlib.import_module("utils")
+
+
+def main() -> None:
+    config_file_path = utils.get_config_file_path()
+    window_base_index = tmux_commands.get_window_base_index()
+    pane_base_index = tmux_commands.get_pane_base_index()
+    session_name = tmux_commands.get_tmux_session_name()
+
+    if not config_file_path:
+        return
+
+    parsed_configuration = utils.parse_config_file(config_file_path=config_file_path)
+
+    if parsed_configuration is None:
+        return
+
+    configurations = utils.generate_configurations(
+        parsed_configuration=parsed_configuration
+    )
+    shared = utils.parse_shared_values(parsed_configuration=parsed_configuration)
+    window_index = tmux_commands.get_current_tmux_window_index()
+
+    config_index = window_index - window_base_index
+    if 0 <= config_index < len(configurations):
+        utils.run_configuration(
+            configuration=configurations[config_index],
+            shared_configuration=shared,
+            session_name=session_name,
+            window_base_index=window_base_index,
+            pane_base_index=pane_base_index,
+            index=config_index,
+            create_or_rename=constants.WindowNamingOption.rename,
+        )
+
+
+main()

--- a/scripts/tmux_commands.py
+++ b/scripts/tmux_commands.py
@@ -193,3 +193,13 @@ def get_pane_base_index() -> int:
         text=True,
     ).stdout
     return int(window_base_index.split(" ")[-1])
+
+
+def get_current_tmux_window_index() -> int:
+    result = subprocess.run(
+        ["tmux", "display-message", "-p", "#I"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return int(result.stdout.strip())

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,0 +1,195 @@
+import importlib
+import typing
+from pathlib import Path
+
+constants = importlib.import_module("constants")
+data_objects = importlib.import_module("data_objects")
+tmux_commands = importlib.import_module("tmux_commands")
+
+
+FILE_NAME = ".tmux-cookie-cutter.yaml"
+CONFIG_PATH = Path.joinpath(Path.home(), ".config")
+
+
+def get_config_file_path() -> Path | None:
+    file_path = Path(FILE_NAME)
+    if file_path.is_file():
+        return file_path
+    else:
+        default_path = Path.joinpath(CONFIG_PATH, FILE_NAME)
+        if Path(default_path).is_file():
+            return default_path
+    return None
+
+
+def parse_config_file(config_file_path: Path) -> dict[str, typing.Any] | None:
+    try:
+        import yaml
+
+        return yaml.safe_load(open(config_file_path))
+    except ModuleNotFoundError:
+        tmux_commands.show_warning_message()
+        return None
+
+
+def generate_pane_configurations(
+    configuration: dict[str, typing.Any],
+) -> list[data_objects.PaneConfig]:
+    pane_configs = configuration.get("panes")
+
+    if pane_configs is None:
+        return []
+
+    return [
+        data_objects.PaneConfig(
+            command=pane_config.get("command"),
+            split_direction=constants.SplitDirection(pane_config["split_direction"]),
+            envvars=configuration.get("envvars"),
+            setup_command=configuration.get("setup_command"),
+            size=pane_config.get("size"),
+        )
+        for pane_config in pane_configs
+    ]
+
+
+def generate_configurations(
+    parsed_configuration: dict[str, typing.Any],
+) -> list[data_objects.Config]:
+    return [
+        data_objects.Config(
+            name=configuration["name"],
+            command=configuration.get("command"),
+            envvars=configuration.get("envvars"),
+            setup_command=configuration.get("setup_command"),
+            panes=generate_pane_configurations(
+                configuration=configuration,
+            ),
+        )
+        for configuration in parsed_configuration["default_windows"]
+    ]
+
+
+def parse_shared_values(
+    parsed_configuration: dict[str, typing.Any],
+) -> data_objects.SharedValues:
+    configuration = parsed_configuration.get("shared")
+    if not configuration:
+        return data_objects.SharedValues(
+            envvars=None,
+            setup_command=None,
+        )
+    return data_objects.SharedValues(
+        envvars=configuration.get("envvars"),
+        setup_command=configuration.get("setup_command"),
+    )
+
+
+def run_pane_configuration(
+    pane_configuration: data_objects.PaneConfig,
+    shared_configuration: data_objects.SharedValues,
+    window_index: int,
+    pane_index: int,
+    session: str,
+) -> None:
+    tmux_commands.split_window(
+        index=window_index,
+        session=session,
+        direction=pane_configuration.split_direction,
+    )
+    tmux_commands.set_environment_variables(
+        envvars=shared_configuration.envvars,
+        index=window_index,
+        session=session,
+    )
+    tmux_commands.run_setup_command(
+        command=shared_configuration.setup_command,
+        index=window_index,
+        session=session,
+    )
+    tmux_commands.set_environment_variables(
+        envvars=pane_configuration.envvars,
+        index=window_index,
+        session=session,
+    )
+    tmux_commands.run_setup_command(
+        command=pane_configuration.setup_command,
+        index=window_index,
+        session=session,
+    )
+    tmux_commands.run_command(
+        command=pane_configuration.command,
+        index=window_index,
+        session=session,
+    )
+    if not pane_configuration.size:
+        return
+
+    match pane_configuration.split_direction:
+        case constants.SplitDirection.vertical:
+            tmux_commands.resize_pane_horizontally(
+                window_index=window_index,
+                pane_index=pane_index,
+                session=session,
+                size=pane_configuration.size,
+            )
+        case constants.SplitDirection.horizontal:
+            tmux_commands.resize_pane_vertically(
+                window_index=window_index,
+                pane_index=pane_index,
+                session=session,
+                size=pane_configuration.size,
+            )
+
+
+def run_configuration(
+    configuration: data_objects.Config,
+    shared_configuration: data_objects.SharedValues,
+    session_name: str,
+    window_base_index: int,
+    pane_base_index: int,
+    index: int,
+    create_or_rename: constants.WindowNamingOption,
+):
+    if create_or_rename == constants.WindowNamingOption.rename:
+        tmux_commands.rename_tmux_window(
+            name=configuration.name,
+            session=session_name,
+            index=index + window_base_index,
+        )
+    elif create_or_rename == constants.WindowNamingOption.create:
+        tmux_commands.create_tmux_window(name=configuration.name, session=session_name)
+
+    tmux_commands.set_environment_variables(
+        envvars=shared_configuration.envvars,
+        index=index + window_base_index,
+        session=session_name,
+    )
+    tmux_commands.run_setup_command(
+        command=shared_configuration.setup_command,
+        index=index + window_base_index,
+        session=session_name,
+    )
+    tmux_commands.set_environment_variables(
+        envvars=configuration.envvars,
+        index=index + window_base_index,
+        session=session_name,
+    )
+    tmux_commands.run_setup_command(
+        command=configuration.setup_command,
+        index=index + window_base_index,
+        session=session_name,
+    )
+    tmux_commands.run_command(
+        command=configuration.command,
+        index=index + window_base_index,
+        session=session_name,
+    )
+
+    for pane_index, pane in enumerate(configuration.panes):
+        run_pane_configuration(
+            pane_configuration=pane,
+            shared_configuration=shared_configuration,
+            window_index=index + window_base_index,
+            pane_index=pane_index + pane_base_index + 1,
+            session=session_name,
+        )


### PR DESCRIPTION
# Summary

This PR adds a new tmux key binding to reload the configuration for the currently active window using <prefix> + Ctrl-c.

# Motivation

Previously, applying configuration changes required restarting tmux or reloading the entire session. This change enables faster iteration by allowing a single window’s configuration to be refreshed in isolation.

# What’s changed

- Added <prefix> + Ctrl-c key binding
- Reloads configuration for the active tmux window only
- No impact on other windows or sessions

# Usage
- Navigate to the window you want to reload.
- Press <prefix> + Ctrl-c.

The window’s configuration will be reloaded immediately.